### PR TITLE
Fix event priority.

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -52,7 +52,7 @@ class Module
         $eventManager   = $app->getEventManager();
 
         $eventManager->attach($serviceManager->get('ZF\ApiProblem\ApiProblemListener'));
-        $eventManager->attach(MvcEvent::EVENT_RENDER, array($this, 'onRender'), 100);
+        $eventManager->attach(MvcEvent::EVENT_RENDER, array($this, 'onRender'), 400);
 
         $sendResponseListener = $serviceManager->get('SendResponseListener');
         $sendResponseListener->getEventManager()->attach(


### PR DESCRIPTION
`Hal`'s renderer listener is attached with priority 100 too, so the 'ZF\ApiProblem\ApiProblemStrategy' listener is executed before the rendering just because right now the module ApiProblem loade first than the module Hal, and that is not cool. I pick 400 as priority value becuase is important that this listener be executed after the `ApiProblemListener::onRender` listener, and the priority of that listener is 1000.

See https://github.com/zfcampus/zf-apigility/pull/17 for related issue.
