### PR TITLE
Merge application response headers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     "require": {
         "php": ">=5.3.23",
         "zendframework/zend-eventmanager": "~2.3",
+        "zendframework/zend-http": "~2.3",
         "zendframework/zend-json": "~2.3",
         "zendframework/zend-mvc": "~2.3",
         "zendframework/zend-view": "~2.3"
@@ -37,7 +38,6 @@
         "phpunit/PHPUnit": "3.7.*",
         "satooshi/php-coveralls": ">=0.6.0",
         "zendframework/zend-console": "~2.3",
-        "zendframework/zend-http": "~2.3",
         "zendframework/zend-loader": "~2.3"
     },
     "autoload": {

--- a/src/Factory/SendApiProblemResponseListenerFactory.php
+++ b/src/Factory/SendApiProblemResponseListenerFactory.php
@@ -6,6 +6,7 @@
 
 namespace ZF\ApiProblem\Factory;
 
+use Zend\Http\Response as HttpResponse;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use ZF\ApiProblem\Listener\SendApiProblemResponseListener;
@@ -25,6 +26,13 @@ class SendApiProblemResponseListenerFactory implements FactoryInterface
 
         $listener = new SendApiProblemResponseListener();
         $listener->setDisplayExceptions($displayExceptions);
+
+        if ($serviceLocator->has('Response')) {
+            $response = $serviceLocator->get('Response');
+            if ($response instanceof HttpResponse) {
+                $listener->setApplicationResponse($response);
+            }
+        }
 
         return $listener;
     }

--- a/test/Listener/SendApiProblemResponseListenerTest.php
+++ b/test/Listener/SendApiProblemResponseListenerTest.php
@@ -81,4 +81,20 @@ class SendApiProblemResponseListenerTest extends TestCase
         $this->assertInternalType('string', $contents);
         $this->assertEmpty($contents);
     }
+
+    public function testSendHeadersMergesApplicationAndProblemHttpHeaders()
+    {
+        $appResponse = new HttpResponse();
+        $appResponse->getHeaders()->addHeaderLine('Access-Control-Allow-Origin', '*');
+
+        $listener = new SendApiProblemResponseListener();
+        $listener->setApplicationResponse($appResponse);
+
+        ob_start();
+        $listener->sendHeaders($this->event);
+        ob_get_clean();
+
+        $headers = $this->response->getHeaders();
+        $this->assertTrue($headers->has('Access-Control-Allow-Origin'));
+    }
 }


### PR DESCRIPTION
- Compose the application response into the SendApiProblemResponseListener
  when
  it is an HTTP response.
- When calling `sendHeaders()`, merge in the application response headers into
  the ApiProblemResponse headers to ensure things such as CORS support will
  function.

This should address:
- zfcampus/zf-rest#17
- zfcampus/zf-apigility#20
- zfcampus/zf-apigility#26

(and will actually require that they be reverted)
