### PR TITLE
Don't interpret exception codes as http statuscodes

### DIFF
--- a/src/Exception/DomainException.php
+++ b/src/Exception/DomainException.php
@@ -26,6 +26,34 @@ class DomainException extends \DomainException implements
     protected $title;
 
     /**
+     * @var integer
+     */
+    protected $httpStatusCode = 500;
+
+    /**
+     * Get httpStatusCode
+     *
+     * @return int
+     */
+    public function getHttpStatusCode()
+    {
+        return $this->httpStatusCode;
+    }
+
+    /**
+     * Set httpStatusCode
+     *
+     * @param int $httpStatusCode
+     *
+     * @return DomainException
+     */
+    public function setHttpStatusCode($httpStatusCode)
+    {
+        $this->httpStatusCode = $httpStatusCode;
+        return $this;
+    }
+
+    /**
      * @param array $details
      * @return self
      */

--- a/src/Exception/ProblemExceptionInterface.php
+++ b/src/Exception/ProblemExceptionInterface.php
@@ -25,4 +25,9 @@ interface ProblemExceptionInterface
      * @return string
      */
     public function getTitle();
+
+    /**
+     * @return int
+     */
+    public function getHttpStatusCode();
 }

--- a/src/Listener/ApiProblemListener.php
+++ b/src/Listener/ApiProblemListener.php
@@ -160,11 +160,7 @@ class ApiProblemListener extends AbstractListenerAggregate
         if ($exception instanceof ProblemExceptionInterface) {
             $problem = new ApiProblem($exception->getCode(), $exception);
         } elseif ($exception instanceof \Exception) {
-            $status = $exception->getCode();
-            if (0 === $status) {
-                $status = 500;
-            }
-            $problem = new ApiProblem($status, $exception);
+            $problem = new ApiProblem(500, $exception);
         } else {
             // If it's not an exception, do not know what to do.
             return;

--- a/src/Listener/ApiProblemListener.php
+++ b/src/Listener/ApiProblemListener.php
@@ -158,7 +158,7 @@ class ApiProblemListener extends AbstractListenerAggregate
         // Marshall an ApiProblem and view model based on the exception
         $exception = $e->getParam('exception');
         if ($exception instanceof ProblemExceptionInterface) {
-            $problem = new ApiProblem($exception->getCode(), $exception);
+            $problem = new ApiProblem($exception->getHttpStatusCode(), $exception);
         } elseif ($exception instanceof \Exception) {
             $problem = new ApiProblem(500, $exception);
         } else {

--- a/test/Listener/ApiProblemListenerTest.php
+++ b/test/Listener/ApiProblemListenerTest.php
@@ -16,6 +16,16 @@ use ZF\ApiProblem\Listener\ApiProblemListener;
 
 class ApiProblemListenerTest extends TestCase
 {
+    /**
+     * @var MvcEvent
+     */
+    protected $event;
+
+    /**
+     * @var ApiProblemListener
+     */
+    protected $listener;
+
     public function setUp()
     {
         $this->event    = new MvcEvent();
@@ -30,14 +40,25 @@ class ApiProblemListenerTest extends TestCase
         $this->assertNull($this->listener->onRender($this->event));
     }
 
-    public function testOnDispatchErrorReturnsAnApiProblemResponseBasedOnCurrentEventException()
+    /**
+     * Short description for the function
+     *
+     * @param $exceptionCode
+     *
+     * @return void
+     *
+     * @dataProvider providePossibleExceptionCodes
+     */
+    public function testOnDispatchErrorReturnsAnApiProblemResponseBasedOnCurrentEventApiProblemExceptionInterface($exceptionCode)
     {
+        $exception = new DomainException('triggering exception', $exceptionCode);
+
         $request = new Request();
         $request->getHeaders()->addHeaderLine('Accept', 'application/json');
 
         $event = new MvcEvent();
         $event->setError(Application::ERROR_EXCEPTION);
-        $event->setParam('exception', new DomainException('triggering exception', 400));
+        $event->setParam('exception', $exception);
         $event->setRequest($request);
         $return = $this->listener->onDispatchError($event);
 
@@ -47,7 +68,54 @@ class ApiProblemListenerTest extends TestCase
         $this->assertSame($return, $response);
         $problem = $response->getApiProblem();
         $this->assertInstanceOf('ZF\ApiProblem\ApiProblem', $problem);
-        $this->assertEquals(400, $problem->status);
+        $this->assertEquals($exceptionCode, $problem->status);
         $this->assertSame($event->getParam('exception'), $problem->detail);
+    }
+
+    /**
+     * Short description for the function
+     *
+     * @param $exceptionCode
+     *
+     * @return void
+     *
+     * @dataProvider providePossibleExceptionCodes
+     */
+    public function testOnDispatchErrorReturnsAnApiProblemResponseBasedOnCurrentEventException($exceptionCode)
+    {
+        $request = new Request();
+        $request->getHeaders()->addHeaderLine('Accept', 'application/json');
+
+        $event = new MvcEvent();
+        $event->setError(Application::ERROR_EXCEPTION);
+        $event->setParam('exception', new \Exception('triggering exception', $exceptionCode));
+        $event->setRequest($request);
+        $return = $this->listener->onDispatchError($event);
+
+        $this->assertTrue($event->propagationIsStopped());
+        $this->assertInstanceOf('ZF\ApiProblem\ApiProblemResponse', $return);
+        $response = $event->getResponse();
+        $this->assertSame($return, $response);
+        $problem = $response->getApiProblem();
+        $this->assertInstanceOf('ZF\ApiProblem\ApiProblem', $problem);
+        $this->assertEquals(500, $problem->status);
+        $this->assertSame($event->getParam('exception'), $problem->detail);
+    }
+
+    public function providePossibleExceptionCodes()
+    {
+        return array(
+            array(PHP_INT_MAX ^ -1), // PHP_INT_MIN
+            array(-8000),
+            array(-500),
+            array(-400),
+            array(-1),
+            array(0),
+            array(1),
+            array(200),
+            array(500),
+            array(8000),
+            array(PHP_INT_MAX),
+        );
     }
 }

--- a/test/Listener/ApiProblemListenerTest.php
+++ b/test/Listener/ApiProblemListenerTest.php
@@ -9,6 +9,8 @@ namespace ZFTest\ApiProblem\Listener;
 use PHPUnit_Framework_TestCase as TestCase;
 use Zend\Console\Request as ConsoleRequest;
 use Zend\Http\Request;
+use Zend\Http\Response;
+use Zend\Json\Server\Response\Http;
 use Zend\Mvc\Application;
 use Zend\Mvc\MvcEvent;
 use ZF\ApiProblem\Exception\DomainException;
@@ -43,15 +45,16 @@ class ApiProblemListenerTest extends TestCase
     /**
      * Short description for the function
      *
-     * @param $exceptionCode
+     * @param $httpStatusCode
      *
      * @return void
      *
-     * @dataProvider providePossibleExceptionCodes
+     * @dataProvider provideHttpStatusCodes
      */
-    public function testOnDispatchErrorReturnsAnApiProblemResponseBasedOnCurrentEventApiProblemExceptionInterface($exceptionCode)
+    public function testOnDispatchErrorReturnsAnApiProblemResponseBasedOnCurrentEventApiProblemExceptionInterface($httpStatusCode)
     {
-        $exception = new DomainException('triggering exception', $exceptionCode);
+        $exception = new DomainException('triggering exception', 404);
+        $exception->setHttpStatusCode($httpStatusCode);
 
         $request = new Request();
         $request->getHeaders()->addHeaderLine('Accept', 'application/json');
@@ -64,12 +67,77 @@ class ApiProblemListenerTest extends TestCase
 
         $this->assertTrue($event->propagationIsStopped());
         $this->assertInstanceOf('ZF\ApiProblem\ApiProblemResponse', $return);
+        /** @var Http $response */
         $response = $event->getResponse();
         $this->assertSame($return, $response);
         $problem = $response->getApiProblem();
         $this->assertInstanceOf('ZF\ApiProblem\ApiProblem', $problem);
-        $this->assertEquals($exceptionCode, $problem->status);
+        $this->assertEquals($httpStatusCode, $problem->status);
         $this->assertSame($event->getParam('exception'), $problem->detail);
+    }
+    
+    public function provideHttpStatusCodes()
+    {
+        return array(
+            array(Response::STATUS_CODE_100),
+            array(Response::STATUS_CODE_101),
+            array(Response::STATUS_CODE_102),
+            array(Response::STATUS_CODE_200),
+            array(Response::STATUS_CODE_201),
+            array(Response::STATUS_CODE_202),
+            array(Response::STATUS_CODE_203),
+            array(Response::STATUS_CODE_204),
+            array(Response::STATUS_CODE_205),
+            array(Response::STATUS_CODE_206),
+            array(Response::STATUS_CODE_207),
+            array(Response::STATUS_CODE_208),
+            array(Response::STATUS_CODE_300),
+            array(Response::STATUS_CODE_301),
+            array(Response::STATUS_CODE_302),
+            array(Response::STATUS_CODE_303),
+            array(Response::STATUS_CODE_304),
+            array(Response::STATUS_CODE_305),
+            array(Response::STATUS_CODE_306),
+            array(Response::STATUS_CODE_307),
+            array(Response::STATUS_CODE_400),
+            array(Response::STATUS_CODE_401),
+            array(Response::STATUS_CODE_402),
+            array(Response::STATUS_CODE_403),
+            array(Response::STATUS_CODE_404),
+            array(Response::STATUS_CODE_405),
+            array(Response::STATUS_CODE_406),
+            array(Response::STATUS_CODE_407),
+            array(Response::STATUS_CODE_408),
+            array(Response::STATUS_CODE_409),
+            array(Response::STATUS_CODE_410),
+            array(Response::STATUS_CODE_411),
+            array(Response::STATUS_CODE_412),
+            array(Response::STATUS_CODE_413),
+            array(Response::STATUS_CODE_414),
+            array(Response::STATUS_CODE_415),
+            array(Response::STATUS_CODE_416),
+            array(Response::STATUS_CODE_417),
+            array(Response::STATUS_CODE_418),
+            array(Response::STATUS_CODE_422),
+            array(Response::STATUS_CODE_423),
+            array(Response::STATUS_CODE_424),
+            array(Response::STATUS_CODE_425),
+            array(Response::STATUS_CODE_426),
+            array(Response::STATUS_CODE_428),
+            array(Response::STATUS_CODE_429),
+            array(Response::STATUS_CODE_431),
+            array(Response::STATUS_CODE_500),
+            array(Response::STATUS_CODE_501),
+            array(Response::STATUS_CODE_501),
+            array(Response::STATUS_CODE_502),
+            array(Response::STATUS_CODE_503),
+            array(Response::STATUS_CODE_504),
+            array(Response::STATUS_CODE_505),
+            array(Response::STATUS_CODE_506),
+            array(Response::STATUS_CODE_507),
+            array(Response::STATUS_CODE_508),
+            array(Response::STATUS_CODE_511),
+        );
     }
 
     /**


### PR DESCRIPTION
This PR should fix issue #27.

ProblemExceptionInterface got a new Method `getHttpStatusCode()` to give transport the http status in your exception. If Exceptions are converted into a ApiProblem-Response, which aren't implementing the ProblemExceptionInterface, we just use the HTTP status code 500.