### PR TITLE
Fix a small typo in the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ class MyController extends AbstractActionController
     {
         $entity = $this->model->fetch($id);
         if (! $entity) {
-            return new ApiProblemResponse(ApiProblem(404, 'Entity not found'));
+            return new ApiProblemResponse(new ApiProblem(404, 'Entity not found'));
         }
         return $entity;
     }


### PR DESCRIPTION
Just a small fix. Noticed the 'new' keyword was missing as I read through the readme.