### PR TITLE
Enable the RenderErrorListener for any Apigility controllers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "zendframework/zend-view": ">=2.3,<2.5"
     },
     "require-dev": {
-        "phpunit/PHPUnit": "3.7.*",
+        "phpunit/phpunit": "~4.7",
         "zendframework/zend-console": ">=2.3,<2.5",
         "zendframework/zend-loader": ">=2.3,<2.5",
         "squizlabs/php_codesniffer": "^2.3"


### PR DESCRIPTION
This patch alters the logic of `ApiProblemListener::onDispatch()` to look not
only for zf-api-problem configuration, but also zf-rest and zf-rpc to
determine which controllers should register the `RenderErrorListener`.

The reason for the change is simple: prior to the patch, the listener only looked under the `zf-api-problem.render_error_controllers` key for controllers that should invoke the `RenderErrorListener`; however, we likely want it registered for any controller handled by Apigility.

Fixes zfcampus/zf-hal#101