### PR TITLE
json_encode fails for streams

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     },
     "require": {
         "php": ">=5.5",
+        "ext-json": "*",
         "zendframework/zend-eventmanager": "~2.3",
         "zendframework/zend-http": "~2.3",
         "zendframework/zend-json": "~2.3",

--- a/src/ApiProblemResponse.php
+++ b/src/ApiProblemResponse.php
@@ -23,7 +23,7 @@ class ApiProblemResponse extends Response
      *
      * @var int
      */
-    protected $jsonFlags = JSON_PARTIAL_OUTPUT_ON_ERROR;
+    protected $jsonFlags;
 
     /**
      * @param ApiProblem $apiProblem
@@ -34,9 +34,7 @@ class ApiProblemResponse extends Response
         $this->setCustomStatusCode($apiProblem->status);
         $this->setReasonPhrase($apiProblem->title);
 
-        if (defined('JSON_UNESCAPED_SLASHES')) {
-            $this->jsonFlags |= constant('JSON_UNESCAPED_SLASHES');
-        }
+        $this->jsonFlags = JSON_UNESCAPED_SLASHES | JSON_PARTIAL_OUTPUT_ON_ERROR;
     }
 
     /**

--- a/src/ApiProblemResponse.php
+++ b/src/ApiProblemResponse.php
@@ -23,7 +23,7 @@ class ApiProblemResponse extends Response
      *
      * @var int
      */
-    protected $jsonFlags = 0;
+    protected $jsonFlags = JSON_PARTIAL_OUTPUT_ON_ERROR;
 
     /**
      * @param ApiProblem $apiProblem
@@ -35,7 +35,7 @@ class ApiProblemResponse extends Response
         $this->setReasonPhrase($apiProblem->title);
 
         if (defined('JSON_UNESCAPED_SLASHES')) {
-            $this->jsonFlags = constant('JSON_UNESCAPED_SLASHES');
+            $this->jsonFlags |= constant('JSON_UNESCAPED_SLASHES');
         }
     }
 

--- a/test/ApiProblemResponseTest.php
+++ b/test/ApiProblemResponseTest.php
@@ -32,9 +32,21 @@ class ApiProblemResponseTest extends TestCase
 
     public function testApiProblemResponseBodyIsSerializedApiProblem()
     {
-        $apiProblem = new ApiProblem(400, 'Random error');
+        $additional = [
+            'foo' => fopen('php://memory', 'r')
+        ];
+
+        $expected = [
+            'foo' => null,
+            'type' => 'http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html',
+            'title' => 'Bad Request',
+            'status' => 400,
+            'detail' => 'Random error',
+        ];
+
+        $apiProblem = new ApiProblem(400, 'Random error', null, null, $additional);
         $response   = new ApiProblemResponse($apiProblem);
-        $this->assertEquals($apiProblem->toArray(), json_decode($response->getContent(), true));
+        $this->assertEquals($expected, json_decode($response->getContent(), true));
     }
 
     /**


### PR DESCRIPTION
I will quote the message from commit 5f7043e:

> ApiProblem was not able to render exceptions when the option
> ApiProblem::detailIncludesStackTrace was true and the exception contained
> PHP streams in the arguments of the traces ("args" key in
> Exception::getTraces()). For example: GuzzleHttp works internally with
> streams which meant that some exceptions raised from GuzzleHttp didn't
> result in a ApiProblem response but in an empty 500 response because
> json_encode() failed.

This PR fixes this issue.

The contribution guidelines didn't specify when to pull request against which branch, so if develop is not the correct target branch for the pull request, please let me know.

Thank you for considering my pull request.