### PR TITLE
Added content-type constant to class ApiProblem

### DIFF
--- a/src/ApiProblem.php
+++ b/src/ApiProblem.php
@@ -12,6 +12,11 @@ namespace ZF\ApiProblem;
 class ApiProblem
 {
     /**
+     * Content type for api problem response
+     */
+    const CONTENT_TYPE = 'application/problem+json';
+    
+    /**
      * Additional details to include in report
      *
      * @var array

--- a/src/ApiProblem.php
+++ b/src/ApiProblem.php
@@ -15,7 +15,7 @@ class ApiProblem
      * Content type for api problem response
      */
     const CONTENT_TYPE = 'application/problem+json';
-    
+
     /**
      * Additional details to include in report
      *

--- a/src/ApiProblemResponse.php
+++ b/src/ApiProblemResponse.php
@@ -71,7 +71,7 @@ class ApiProblemResponse extends Response
     {
         $headers = parent::getHeaders();
         if (!$headers->has('content-type')) {
-            $headers->addHeaderLine('content-type', 'application/problem+json');
+            $headers->addHeaderLine('content-type', ApiProblem::CONTENT_TYPE);
         }
         return $headers;
     }

--- a/src/Listener/RenderErrorListener.php
+++ b/src/Listener/RenderErrorListener.php
@@ -10,6 +10,7 @@ use Zend\EventManager\EventManagerInterface;
 use Zend\EventManager\AbstractListenerAggregate;
 use Zend\Mvc\MvcEvent;
 use Zend\View\Exception\ExceptionInterface as ViewExceptionInterface;
+use ZF\ApiProblem\ApiProblem;
 
 /**
  * RenderErrorListener
@@ -89,7 +90,7 @@ class RenderErrorListener extends AbstractListenerAggregate
             $payload['details'] = $details;
         }
 
-        $response->getHeaders()->addHeaderLine('content-type', 'application/problem+json');
+        $response->getHeaders()->addHeaderLine('content-type', ApiProblem::CONTENT_TYPE);
         $response->setStatusCode($status);
         $response->setContent(json_encode($payload));
 

--- a/src/View/ApiProblemStrategy.php
+++ b/src/View/ApiProblemStrategy.php
@@ -72,7 +72,7 @@ class ApiProblemStrategy extends JsonStrategy
 
         $problem     = $model->getApiProblem();
         $statusCode  = $this->getStatusCodeFromApiProblem($problem);
-        $contentType = 'application/problem+json';
+        $contentType = ApiProblem::CONTENT_TYPE;
 
         // Populate response
         $response = $e->getResponse();

--- a/test/ApiProblemResponseTest.php
+++ b/test/ApiProblemResponseTest.php
@@ -47,7 +47,7 @@ class ApiProblemResponseTest extends TestCase
         $this->assertTrue($headers->has('content-type'));
         $header = $headers->get('content-type');
         $this->assertInstanceOf('Zend\Http\Header\ContentType', $header);
-        $this->assertEquals('application/problem+json', $header->getFieldValue());
+        $this->assertEquals(ApiProblem::CONTENT_TYPE, $header->getFieldValue());
     }
 
     public function testComposeApiProblemIsAccessible()

--- a/test/Listener/RenderErrorListenerTest.php
+++ b/test/Listener/RenderErrorListenerTest.php
@@ -43,7 +43,7 @@ class RenderErrorListenerTest extends TestCase
         $this->assertEquals(406, $response->getStatusCode());
         $headers = $response->getHeaders();
         $this->assertTrue($headers->has('Content-Type'));
-        $this->assertEquals('application/problem+json', $headers->get('content-type')->getFieldValue());
+        $this->assertEquals(ApiProblem::CONTENT_TYPE, $headers->get('content-type')->getFieldValue());
         $content = json_decode($response->getContent(), true);
         $this->assertArrayHasKey('status', $content);
         $this->assertArrayHasKey('title', $content);

--- a/test/Listener/RenderErrorListenerTest.php
+++ b/test/Listener/RenderErrorListenerTest.php
@@ -11,6 +11,7 @@ use Zend\Http\Request;
 use Zend\Http\Response;
 use Zend\Mvc\Application;
 use Zend\Mvc\MvcEvent;
+use ZF\ApiProblem\ApiProblem;
 use ZF\ApiProblem\Listener\RenderErrorListener;
 
 class RenderErrorListenerTest extends TestCase

--- a/test/View/ApiProblemStrategyTest.php
+++ b/test/View/ApiProblemStrategyTest.php
@@ -78,7 +78,7 @@ class ApiProblemStrategyTest extends TestCase
         $headers = $this->response->getHeaders();
         $this->assertTrue($headers->has('Content-Type'));
         $header = $headers->get('Content-Type');
-        $this->assertEquals('application/problem+json', $header->getFieldValue());
+        $this->assertEquals(ApiProblem::CONTENT_TYPE, $header->getFieldValue());
     }
 
     public function invalidStatusCodes()


### PR DESCRIPTION
Added a content-type constant to the class ApiProblem and used it inside the ApiProblemResponse class. It will make it much easier to refer to the correct content type without having to retype/hardcode the `application/problem+json` string everywhere we need it.