### PR TITLE
Ensure all factories are compatible with both major versions of zend-servicemanager

### DIFF
--- a/src/Factory/ApiProblemListenerFactory.php
+++ b/src/Factory/ApiProblemListenerFactory.php
@@ -1,32 +1,27 @@
 <?php
-
 /**
  * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2014-2016 Zend Technologies USA Inc. (http://www.zend.com)
  */
 
 namespace ZF\ApiProblem\Factory;
 
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\Factory\FactoryInterface;
 use ZF\ApiProblem\Listener\ApiProblemListener;
 
-class ApiProblemListenerFactory implements FactoryInterface
+class ApiProblemListenerFactory
 {
     /**
-     * @param \Interop\Container\ContainerInterface $container
-     * @param string                                $requestedName
-     * @param array|NULL                            $options
-     *
-     * @return \ZF\ApiProblem\Listener\ApiProblemListener
+     * @param ContainerInterface $container
+     * @return ApiProblemListener
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container)
     {
         $filters = null;
         $config = [];
 
-        if ($container->has('Config')) {
-            $config = $container->get('Config');
+        if ($container->has('config')) {
+            $config = $container->get('config');
         }
 
         if (isset($config['zf-api-problem']['accept_filters'])) {

--- a/src/Factory/ApiProblemRendererFactory.php
+++ b/src/Factory/ApiProblemRendererFactory.php
@@ -1,31 +1,23 @@
 <?php
-
 /**
  * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2014-2016 Zend Technologies USA Inc. (http://www.zend.com)
  */
 
 namespace ZF\ApiProblem\Factory;
 
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\Factory\FactoryInterface;
 use ZF\ApiProblem\View\ApiProblemRenderer;
 
-/**
- * Class ApiProblemRendererFactory.
- */
-class ApiProblemRendererFactory implements FactoryInterface
+class ApiProblemRendererFactory
 {
     /**
-     * @param \Interop\Container\ContainerInterface $container
-     * @param string                                $requestedName
-     * @param array|NULL                            $options
-     *
-     * @return \ZF\ApiProblem\View\ApiProblemRenderer
+     * @param ContainerInterface $container
+     * @return ApiProblemRenderer
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container)
     {
-        $config = $container->get('Config');
+        $config = $container->get('config');
         $displayExceptions = isset($config['view_manager'])
             && isset($config['view_manager']['display_exceptions'])
             && $config['view_manager']['display_exceptions'];

--- a/src/Factory/ApiProblemStrategyFactory.php
+++ b/src/Factory/ApiProblemStrategyFactory.php
@@ -1,30 +1,22 @@
 <?php
-
 /**
  * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2014-2016 Zend Technologies USA Inc. (http://www.zend.com)
  */
 
 namespace ZF\ApiProblem\Factory;
 
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\Factory\FactoryInterface;
 use ZF\ApiProblem\View\ApiProblemRenderer;
 use ZF\ApiProblem\View\ApiProblemStrategy;
 
-/**
- * Class ApiProblemStrategyFactory.
- */
-class ApiProblemStrategyFactory implements FactoryInterface
+class ApiProblemStrategyFactory
 {
     /**
-     * @param \Interop\Container\ContainerInterface $container
-     * @param string                                $requestedName
-     * @param array|NULL                            $options
-     *
-     * @return \ZF\ApiProblem\View\ApiProblemStrategy
+     * @param ContainerInterface $container
+     * @return ApiProblemStrategy
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container)
     {
         return new ApiProblemStrategy($container->get(ApiProblemRenderer::class));
     }

--- a/src/Factory/RenderErrorListenerFactory.php
+++ b/src/Factory/RenderErrorListenerFactory.php
@@ -1,31 +1,23 @@
 <?php
-
 /**
  * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2014-2016 Zend Technologies USA Inc. (http://www.zend.com)
  */
 
 namespace ZF\ApiProblem\Factory;
 
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\Factory\FactoryInterface;
 use ZF\ApiProblem\Listener\RenderErrorListener;
 
-/**
- * Class RenderErrorListenerFactory.
- */
-class RenderErrorListenerFactory implements FactoryInterface
+class RenderErrorListenerFactory
 {
     /**
-     * @param \Interop\Container\ContainerInterface $container
-     * @param string                                $requestedName
-     * @param array|NULL                            $options
-     *
-     * @return \ZF\ApiProblem\Listener\RenderErrorListener
+     * @param ContainerInterface $container
+     * @return RenderErrorListener
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container)
     {
-        $config = $container->get('Config');
+        $config = $container->get('config');
         $displayExceptions = false;
 
         if (isset($config['view_manager'])

--- a/src/Factory/SendApiProblemResponseListenerFactory.php
+++ b/src/Factory/SendApiProblemResponseListenerFactory.php
@@ -1,22 +1,24 @@
 <?php
-
 /**
  * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
- * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @copyright Copyright (c) 2014-2016 Zend Technologies USA Inc. (http://www.zend.com)
  */
 
 namespace ZF\ApiProblem\Factory;
 
 use Interop\Container\ContainerInterface;
 use Zend\Http\Response as HttpResponse;
-use Zend\ServiceManager\Factory\FactoryInterface;
 use ZF\ApiProblem\Listener\SendApiProblemResponseListener;
 
-class SendApiProblemResponseListenerFactory implements FactoryInterface
+class SendApiProblemResponseListenerFactory
 {
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    /**
+     * @param ContainerInterface $container
+     * @return SendApiProblemResponseListener
+     */
+    public function __invoke(ContainerInterface $container)
     {
-        $config = $container->get('Config');
+        $config = $container->get('config');
         $displayExceptions = isset($config['view_manager'])
             && isset($config['view_manager']['display_exceptions'])
             && $config['view_manager']['display_exceptions'];


### PR DESCRIPTION
- Removed `FactoryInterface` implmentation at class level; since each now implements an `__invoke()` method, they are each compatible with both major versions.
- Updated all factories to only accept the arguments they use (as we are not implementing an interface).
- Ensured all factories that pull the config service use `config` vs `Config` for forwards compatibility.