### PR TITLE
Add the ability to return the raw detail of the api problem

### DIFF
--- a/src/ApiProblem.php
+++ b/src/ApiProblem.php
@@ -234,14 +234,16 @@ class ApiProblem
     /**
      * Retrieve the API-Problem detail.
      *
-     * If an exception was provided, creates the detail message from it;
+     * If an exception was provided (and raw == false), creates the detail message from it;
      * otherwise, detail as provided is used.
+     *
+     * @param bool $raw (default false)
      *
      * @return string
      */
-    protected function getDetail()
+    public function getDetail($raw = false)
     {
-        if ($this->detail instanceof Throwable || $this->detail instanceof Exception) {
+        if (!$raw && ($this->detail instanceof Throwable || $this->detail instanceof Exception)) {
             return $this->createDetailFromException();
         }
 

--- a/src/ApiProblem.php
+++ b/src/ApiProblem.php
@@ -234,19 +234,27 @@ class ApiProblem
     /**
      * Retrieve the API-Problem detail.
      *
-     * If an exception was provided (and raw == false), creates the detail message from it;
+     * If an exception was provided, creates the detail message from it;
      * otherwise, detail as provided is used.
-     *
-     * @param bool $raw (default false)
      *
      * @return string
      */
-    public function getDetail($raw = false)
+    public function getDetail()
     {
-        if (!$raw && ($this->detail instanceof Throwable || $this->detail instanceof Exception)) {
+        if ($this->detail instanceof Throwable || $this->detail instanceof Exception) {
             return $this->createDetailFromException();
         }
 
+        return $this->detail;
+    }
+
+    /**
+     * Retrieve the raw API-Problem detail.
+     *
+     * @return string|Exception|Throwable
+     */
+    public function getRawDetail()
+    {
         return $this->detail;
     }
 

--- a/src/ApiProblem.php
+++ b/src/ApiProblem.php
@@ -258,7 +258,7 @@ class ApiProblem
      *
      * @return string
      */
-    protected function getStatus()
+    public function getStatus()
     {
         if ($this->detail instanceof Throwable || $this->detail instanceof Exception) {
             $this->status = $this->createStatusFromException();

--- a/test/ApiProblemTest.php
+++ b/test/ApiProblemTest.php
@@ -54,6 +54,8 @@ class ApiProblemTest extends TestCase
         $this->assertEquals(705, $payload['status']);
         $this->assertArrayHasKey('detail', $payload);
         $this->assertEquals('error message', $payload['detail']);
+        $this->assertEquals('error message', $apiProblem->getDetail());
+        $this->assertSame($error, $apiProblem->getRawDetail());
     }
 
     public function testExceptionCodeIsUsedForStatus()
@@ -71,6 +73,8 @@ class ApiProblemTest extends TestCase
         $payload = $apiProblem->toArray();
         $this->assertArrayHasKey('detail', $payload);
         $this->assertEquals('foo', $payload['detail']);
+        $this->assertEquals('foo', $apiProblem->getDetail());
+        $this->assertEquals('foo', $apiProblem->getRawDetail());
     }
 
     public function testExceptionMessageIsUsedForDetail()
@@ -80,6 +84,8 @@ class ApiProblemTest extends TestCase
         $payload = $apiProblem->toArray();
         $this->assertArrayHasKey('detail', $payload);
         $this->assertEquals($exception->getMessage(), $payload['detail']);
+        $this->assertEquals('exception message', $apiProblem->getDetail());
+        $this->assertSame($exception, $apiProblem->getRawDetail());
     }
 
     public function testExceptionsCanTriggerInclusionOfStackTraceInDetails()


### PR DESCRIPTION
In my custom error logger I want to log the raw detail of an api problem (e. g. an exception) in order to have the stacktrace in the same format as any other exception thrown in a ZF2 application.

This PR alters the `ApiProblem::getDetail()` method:
* makes it public to allow retrieving the detail
* adds a parameter "bool $raw" (default false) to allow the return of the raw detail (the exception) instead of an string.
* also makes the getStatus() method public too

Or would you rather prefer a new method `ApiProblem::getRawDetail()` instead of altering the existing method?